### PR TITLE
Fix link to GitHub from footer

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -64,12 +64,12 @@ const siteConfig = {
             {
               key: 5,
               label: 'GitHub',
-              href: '/callstack/react-native-testing-library',
+              href: repoUrl,
             },
             {
               key: 6,
               label: 'Star',
-              href: '/callstack/react-native-testing-library',
+              href: repoUrl,
             },
           ],
         },


### PR DESCRIPTION
The website is not correctly linking to github. It links to https://callstack.github.io/callstack/react-native-testing-library instead